### PR TITLE
implement custom page and article list endpoint

### DIFF
--- a/drupal/lobbywatch/lobbywatch_meta/lobbywatch_meta.inc
+++ b/drupal/lobbywatch/lobbywatch_meta/lobbywatch_meta.inc
@@ -49,3 +49,129 @@ function _lobbywatch_meta() {
   ));
   drupal_exit();
 }
+
+function _lobbywatch_meta_property_access_filter($wrapper) {
+  $filtered = array();
+  foreach ($wrapper as $name => $property) {
+    try {
+      if ($property->access('view')) {
+        $filtered[$name] = $property;
+      }
+    }
+    // Some properties like entity_metadata_book_get_properties() throw
+    // exceptions, so we catch them here and ignore the property (deny access).
+    catch (EntityMetadataWrapperException $e) {}
+  }
+  return $filtered;
+}
+
+function _lobbywatch_meta_get_data($wrapper, $recursive = FALSE, $load_types = array(), $data = array()) {
+  $filtered = _lobbywatch_meta_property_access_filter($wrapper);
+
+  foreach ($filtered as $name => $property) {
+    try {
+      if ($property instanceof EntityDrupalWrapper) {
+        if ($recursive && in_array($property->type(), $load_types)) {
+          $data[$name] = _lobbywatch_meta_get_data(
+            entity_metadata_wrapper($property->type(), $property->value())
+          );
+          if ($property->type() === 'file') {
+            $data = $data[$name];
+          }
+        }
+      }
+      elseif ($property instanceof EntityValueWrapper) {
+        $data[$name] = $property->value();
+      }
+      elseif ($property instanceof EntityListWrapper || $property instanceof EntityStructureWrapper) {
+        $data[$name] = _lobbywatch_meta_get_data($property, $recursive, $load_types);
+      }
+    }
+    catch (EntityMetadataWrapperException $e) {
+      // A property causes problems - ignore that.
+    }
+  }
+  return $data;
+}
+
+function _lobbywatch_meta_get_node_data($values) {
+  $wrapper = entity_metadata_wrapper('node', $values);
+
+  $translations = translation_path_get_translations('node/'.$values->nid);
+  foreach ($translations as $lang => $path) {
+    $translations[$lang] = drupal_get_path_alias($path, $lang);
+  }
+
+  $load_types = isset($_GET['load-entity-refs'])
+    ? explode(',', $_GET['load-entity-refs'])
+    : array();
+
+  $data = _lobbywatch_meta_get_data($wrapper, TRUE, $load_types, array(
+    'path' => drupal_get_path_alias('node/'.$values->nid),
+    'translations' => $translations
+  ));
+
+  if (!$data['field_author']) {
+    $data['field_author'] = $wrapper->author->name->value();
+  }
+
+  return $data;
+}
+
+function _lobbywatch_meta_load_nodes($ids) {
+  $dataSet = entity_load('node', $ids);
+
+  return array_map('_lobbywatch_meta_get_node_data', array_values($dataSet));
+}
+
+function _lobbywatch_meta_page() {
+  list($type, $id) = explode('/', drupal_get_normal_path($_GET['url']));
+  $data = _lobbywatch_meta_load_nodes([$id]);
+
+  if (!$data[0]) {
+    drupal_add_http_header('Status', '404', $append = FALSE);
+  }
+  drupal_json_output($data[0]);
+  drupal_exit();
+}
+
+function _lobbywatch_meta_articles() {
+  $query = new EntityFieldQuery();
+  $query
+    ->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'article')
+    ->propertyCondition('status', NODE_PUBLISHED)
+    ->propertyCondition('promote', 1)
+    ->propertyOrderBy('created', 'DESC');
+
+  $limit = min(array(100, isset($_GET['limit']) ? intval($_GET['limit']) : 10));
+  $offset = isset($_GET['page']) ? intval($_GET['page']) : 0;
+  $offset *= $limit;
+
+  $query->range($offset, $limit);
+
+  try {
+    $query_result = $query->execute();
+  }
+  catch (PDOException $exception) {
+    throw new RestWSException('Query failed.', 400);
+  }
+  $query_result = isset($query_result['node']) ? $query_result['node'] : array();
+
+  $articleIds = array_keys($query_result);
+
+  $query = new EntityFieldQuery();
+  $query
+    ->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'article')
+    ->propertyCondition('status', NODE_PUBLISHED)
+    ->propertyCondition('promote', 1);
+  $total = $query->count()->execute();
+
+  drupal_json_output(array(
+    'total' => $total,
+    'pages' => floor($total / $limit),
+    'list' => _lobbywatch_meta_load_nodes($articleIds)
+  ));
+  drupal_exit();
+}

--- a/drupal/lobbywatch/lobbywatch_meta/lobbywatch_meta.module
+++ b/drupal/lobbywatch/lobbywatch_meta/lobbywatch_meta.module
@@ -13,6 +13,20 @@ function lobbywatch_meta_menu() {
     'type' => MENU_CALLBACK,
     'file' => 'lobbywatch_meta.inc',
   );
+  $items['daten/page'] = array(
+    'page callback' => '_lobbywatch_meta_page',
+    'page arguments' => array(),
+    'access arguments' => array('access lobbywatch page content'),
+    'type' => MENU_CALLBACK,
+    'file' => 'lobbywatch_meta.inc',
+  );
+  $items['daten/articles'] = array(
+    'page callback' => '_lobbywatch_meta_articles',
+    'page arguments' => array(),
+    'access arguments' => array('access lobbywatch article content'),
+    'type' => MENU_CALLBACK,
+    'file' => 'lobbywatch_meta.inc',
+  );
 
   return $items;
 }
@@ -24,6 +38,12 @@ function lobbywatch_meta_permission() {
   return array(
     'access lobbywatch meta content' => array(
       'title' => t('Access lobbywatch meta content'),
+    ),
+    'access lobbywatch page content' => array(
+      'title' => t('Access lobbywatch page content'),
+    ),
+    'access lobbywatch article content' => array(
+      'title' => t('Access lobbywatch article content'),
     )
   );
 }


### PR DESCRIPTION
Add the following API endpoint:
`/de/daten/page?url=artikel/wandelhalle-persoenlich-burson-marsteller-stockt&load-entity-refs=taxonomy_term,file`
`/de/daten/articles?limit=10&page=0`

This is a simple version of `restws` and `restws_entityreference` built into the `lobbywatch_meta` sub-module. But hopefully circumventing the url resolving issues in production that we're having with them.